### PR TITLE
Remove unnecessary package namespace

### DIFF
--- a/src/Frozennode/Administrator/Menu.php
+++ b/src/Frozennode/Administrator/Menu.php
@@ -45,7 +45,7 @@ class Menu {
 
 		if (!$subMenu)
 		{
-			$subMenu = $this->config->get('administrator::administrator.menu');
+			$subMenu = $this->config->get('administrator.menu');
 		}
 
 		//iterate over the menu to build the return array of valid menu items


### PR DESCRIPTION
When i was installing the site this gave me an error. After removing `administrator::` everything worked well.